### PR TITLE
Fix error subclassing

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,9 +2,8 @@ name: Publish Documentation
 
 on:
   push:
-  pull_request:
     branches:
-      - '**'
+      - 'main'
 
 jobs:
   deploy:

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,6 +1,7 @@
 pygments
 mkdocs
 mkdocstrings
+mkdocstrings-python
 mkdocs-material
 livereload
 pytkdocs[numpy-style]

--- a/lume/serializers/base.py
+++ b/lume/serializers/base.py
@@ -1,6 +1,24 @@
 from abc import ABC, abstractmethod
 
 
+class ModuleImportError(Exception):
+    def __init__(self, module_name, module_version):
+        self.module_name = module_name
+        module_base = module_name.split(".")[0]
+        module_version = module_version
+        self.message = f"Unable to import module {module_name}. Object was serialized with {module_version}. Is a compatible version of {module_base} installed?"
+        super().__init__(self.message)
+
+
+class ClassInitError(Exception):
+    def __init__(self, class_name, module_name, module_version):
+        self.module_name = module_name
+        self.class_name = class_name
+        module_base = module_name.split(".")[0]
+        self.message = f"Unable to get {class_name} from {module_name}. Object was serialized with {module_version}. Is a compatible version of {module_base} installed?"
+        super().__init__(self.message)
+
+
 class SerializerBase(ABC):
     """Base class for serializers."""
 

--- a/lume/serializers/hdf5.py
+++ b/lume/serializers/hdf5.py
@@ -1,4 +1,4 @@
-from .base import SerializerBase
+from .base import SerializerBase, ModuleImportError, ClassInitError
 import h5py
 import importlib
 import numpy as np
@@ -10,22 +10,6 @@ if TYPE_CHECKING:
     from lume.base import Base
 
 
-class ModuleImportError(Exception):
-    def __init__(self, module_name, module_version):
-        self.module_name = module_name
-        module_base = module_name.split(".")[0]
-        module_version = module_version
-        self.message = f"Unable to import module {module_name}. Object was serialized with {module_version}. Is a compatible version of {module_base} installed?"
-        super().__init__(self.message)
-
-
-class ClassInitError(Exception):
-    def __init__(self, class_name, module_name, module_version):
-        self.module_name = module_name
-        self.class_name = class_name
-        module_base = module_name.split(".")[0]
-        self.message = f"Unable to get {class_name} from {module_name}. Object was serialized with {module_version}. Is a compatible version of {module_base} installed?"
-        super().__init__(self.message)
 
 
 class HDF5Serializer(SerializerBase):

--- a/lume/serializers/hdf5.py
+++ b/lume/serializers/hdf5.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from lume.base import Base
 
 
-class ModuleImportError:
+class ModuleImportError(Exception):
     def __init__(self, module_name, module_version):
         self.module_name = module_name
         module_base = module_name.split(".")[0]
@@ -19,7 +19,7 @@ class ModuleImportError:
         super().__init__(self.message)
 
 
-class ClassInitError:
+class ClassInitError(Exception):
     def __init__(self, class_name, module_name, module_version):
         self.module_name = module_name
         self.class_name = class_name


### PR DESCRIPTION
Errors must be subclasses of Exception for the `super().__init__(self.message)` to mean anything.

Additionally, this PR removes doc build on PR and adds mkdocstrings-python handlers which need to be installed separately with latest mkdocstrings releases.