### PR TITLE
Update `openpmd-beamphysics` Import

### DIFF
--- a/lume/base.py
+++ b/lume/base.py
@@ -5,7 +5,11 @@ import warnings
 from abc import ABC, abstractmethod
 
 import yaml
-from beamphysics import ParticleGroup
+
+try:
+    from beamphysics import ParticleGroup
+except ImportError:
+    from pmd_beamphysics import ParticleGroup
 
 from lume.serializers.hdf5 import HDF5Serializer
 

--- a/lume/base.py
+++ b/lume/base.py
@@ -5,7 +5,7 @@ import warnings
 from abc import ABC, abstractmethod
 
 import yaml
-from pmd_beamphysics import ParticleGroup
+from beamphysics import ParticleGroup
 
 from lume.serializers.hdf5 import HDF5Serializer
 

--- a/lume/tests/variables/test_particle_group.py
+++ b/lume/tests/variables/test_particle_group.py
@@ -6,7 +6,7 @@ from lume.variables.particle_group import ParticleGroupVariable
 
 # Try to import ParticleGroup, mark tests as skipped if not available
 try:
-    from pmd_beamphysics import ParticleGroup
+    from beamphysics import ParticleGroup
 
     PARTICLE_GROUP_AVAILABLE = True
 except ImportError:
@@ -14,7 +14,7 @@ except ImportError:
     ParticleGroup = None
 
 pytestmark = pytest.mark.skipif(
-    not PARTICLE_GROUP_AVAILABLE, reason="pmd_beamphysics not available"
+    not PARTICLE_GROUP_AVAILABLE, reason="beamphysics not available"
 )
 
 

--- a/lume/tests/variables/test_particle_group.py
+++ b/lume/tests/variables/test_particle_group.py
@@ -10,8 +10,13 @@ try:
 
     PARTICLE_GROUP_AVAILABLE = True
 except ImportError:
-    PARTICLE_GROUP_AVAILABLE = False
-    ParticleGroup = None
+    try:
+        from pmd_beamphysics import ParticleGroup
+
+        PARTICLE_GROUP_AVAILABLE = True
+    except ImportError:
+        PARTICLE_GROUP_AVAILABLE = False
+        ParticleGroup = None
 
 pytestmark = pytest.mark.skipif(
     not PARTICLE_GROUP_AVAILABLE, reason="beamphysics not available"

--- a/lume/variables/particle_group.py
+++ b/lume/variables/particle_group.py
@@ -5,7 +5,11 @@ Module that creates a variable type for openpmd-beamphysics particle groups.
 from typing import Any
 
 from lume.variables.variable import Variable
-from beamphysics import ParticleGroup
+
+try:
+    from beamphysics import ParticleGroup
+except ImportError:
+    from pmd_beamphysics import ParticleGroup
 
 
 class ParticleGroupVariable(Variable):

--- a/lume/variables/particle_group.py
+++ b/lume/variables/particle_group.py
@@ -5,7 +5,7 @@ Module that creates a variable type for openpmd-beamphysics particle groups.
 from typing import Any
 
 from lume.variables.variable import Variable
-from pmd_beamphysics import ParticleGroup
+from beamphysics import ParticleGroup
 
 
 class ParticleGroupVariable(Variable):


### PR DESCRIPTION
`OpenPMD-Beamphysics` renamed their import from `pmd_beamphysics` to `beamphysics`. This PR updates the imports with fallbacks tot he old name in case users have the older version installed.