### PR TITLE
revert arbitrary enum by to list enum

### DIFF
--- a/lume/tests/variables/test_enum.py
+++ b/lume/tests/variables/test_enum.py
@@ -10,129 +10,67 @@ class TestEnumVariable:
 
     def test_options_validation_empty(self):
         with pytest.raises(ValueError, match="options must not be empty"):
-            EnumVariable(name="test", options={})
+            EnumVariable(name="test", options=[])
 
-    def test_options_validation_non_dict(self):
-        with pytest.raises(ValueError, match="options must be a dictionary"):
-            EnumVariable(name="test", options=["a", "b", "c"])
+    def test_options_validation_non_list(self):
+        with pytest.raises(ValueError, match="options must be a list or tuple"):
+            EnumVariable(name="test", options="invalid")
 
-    def test_options_validation_non_int_keys(self):
-        with pytest.raises(ValueError, match="All option keys must be integers"):
-            EnumVariable(name="test", options={"a": "label_a", "b": "label_b"})
+    def test_options_converted_to_list(self):
+        var = EnumVariable(name="test", options=("a", "b", "c"))
+        assert var.options == ["a", "b", "c"]
+        assert isinstance(var.options, list)
 
-    def test_options_validation_non_str_values(self):
-        with pytest.raises(ValueError, match="All option values must be strings"):
-            EnumVariable(name="test", options={0: "red", 1: 2})
+    def test_default_value_must_be_in_options(self):
+        with pytest.raises(ValueError, match="not one of the allowed options"):
+            EnumVariable(name="test", options=["a", "b", "c"], default_value="d")
 
-    def test_default_value_with_int_key(self):
-        var = EnumVariable(
-            name="test", options={0: "red", 1: "green", 2: "blue"}, default_value=0
-        )
-        assert var.default_value == 0
+    def test_default_value_validated(self):
+        var = EnumVariable(name="test", options=["a", "b", "c"], default_value="a")
+        assert var.default_value == "a"
 
-    def test_default_value_with_str_label(self):
-        var = EnumVariable(
-            name="test",
-            options={0: "red", 1: "green", 2: "blue"},
-            default_value="red",
-        )
-        assert var.default_value == "red"
+    def test_validate_string_options(self):
+        var = EnumVariable(name="test", options=["red", "green", "blue"])
+        var.validate_value("red", config="error")
+        var.validate_value("green", config="error")
+        var.validate_value("blue", config="error")
 
-    def test_default_value_invalid_int_key(self):
-        with pytest.raises(ValueError, match="not a valid key or label"):
-            EnumVariable(
-                name="test",
-                options={0: "red", 1: "green", 2: "blue"},
-                default_value=99,
-            )
-
-    def test_default_value_invalid_str_label(self):
-        with pytest.raises(ValueError, match="not a valid key or label"):
-            EnumVariable(
-                name="test",
-                options={0: "red", 1: "green", 2: "blue"},
-                default_value="yellow",
-            )
-
-    def test_validate_with_int_key(self):
-        var = EnumVariable(name="test", options={0: "red", 1: "green", 2: "blue"})
-        var.validate_value(0, config="error")
+    def test_validate_numeric_options(self):
+        var = EnumVariable(name="test", options=[1, 2, 3])
         var.validate_value(1, config="error")
         var.validate_value(2, config="error")
+        var.validate_value(3, config="error")
 
-    def test_validate_with_str_label(self):
-        var = EnumVariable(name="test", options={0: "red", 1: "green", 2: "blue"})
-        var.validate_value("red", config="error")
-        var.validate_value("green", config="error")
-        var.validate_value("blue", config="error")
+    def test_validate_mixed_type_options(self):
+        var = EnumVariable(name="test", options=[1, "a", 2.5, None])
+        var.validate_value(1, config="error")
+        var.validate_value("a", config="error")
+        var.validate_value(2.5, config="error")
+        var.validate_value(None, config="error")
 
-    def test_validate_arbitrary_int_mapping(self):
-        var = EnumVariable(name="test", options={5: "red", 10: "green", 15: "blue"})
-        var.validate_value(5, config="error")
-        var.validate_value(10, config="error")
-        var.validate_value(15, config="error")
-        var.validate_value("red", config="error")
-        var.validate_value("green", config="error")
-        var.validate_value("blue", config="error")
-
-    def test_reject_invalid_int_key(self):
-        var = EnumVariable(name="test", options={0: "red", 1: "green", 2: "blue"})
-        with pytest.raises(ValueError, match="not a valid key or label"):
-            var.validate_value(99, config="error")
-
-    def test_reject_invalid_str_label(self):
-        var = EnumVariable(name="test", options={0: "red", 1: "green", 2: "blue"})
-        with pytest.raises(ValueError, match="not a valid key or label"):
-            var.validate_value("yellow", config="error")
-
-    def test_validate_rejects_non_int_str_types(self):
-        var = EnumVariable(name="test", options={0: "red", 1: "green", 2: "blue"})
-        for invalid in [1.5, None, [], {}]:
-            with pytest.raises(TypeError, match="Expected value to be int or str"):
-                var.validate_value(invalid, config="error")
+    def test_reject_invalid_value(self):
+        var = EnumVariable(name="test", options=["a", "b", "c"])
+        with pytest.raises(ValueError, match="not one of the allowed options"):
+            var.validate_value("d", config="error")
 
     def test_validation_with_config_warn(self):
-        var = EnumVariable(name="test", options={0: "red", 1: "green", 2: "blue"})
+        var = EnumVariable(name="test", options=["a", "b", "c"])
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            var.validate_value(99, config="warn")
+            var.validate_value("d", config="warn")
             assert len(w) == 1
-            assert "not a valid key or label" in str(w[0].message)
+            assert "not one of the allowed options" in str(w[0].message)
 
-    def test_validation_with_config_none(self):
-        var = EnumVariable(name="test", options={0: "red", 1: "green", 2: "blue"})
-        # config="none" should not raise or warn for invalid values
-        var.validate_value(99, config="none")
+    def test_validation_with_config_error(self):
+        var = EnumVariable(name="test", options=["a", "b", "c"])
+        with pytest.raises(ValueError, match="not one of the allowed options"):
+            var.validate_value("d", config="error")
 
     def test_validation_uses_default_config(self):
         var = EnumVariable(
-            name="test",
-            options={0: "red", 1: "green", 2: "blue"},
-            default_validation_config="warn",
+            name="test", options=["a", "b", "c"], default_validation_config="warn"
         )
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            var.validate_value(99)
+            var.validate_value("d")
             assert len(w) == 1
-
-    def test_get_label(self):
-        var = EnumVariable(name="test", options={0: "red", 1: "green", 2: "blue"})
-        assert var.get_label(0) == "red"
-        assert var.get_label(1) == "green"
-        assert var.get_label(2) == "blue"
-
-    def test_get_label_invalid_key(self):
-        var = EnumVariable(name="test", options={0: "red", 1: "green", 2: "blue"})
-        with pytest.raises(KeyError):
-            var.get_label(99)
-
-    def test_get_key(self):
-        var = EnumVariable(name="test", options={0: "red", 1: "green", 2: "blue"})
-        assert var.get_key("red") == 0
-        assert var.get_key("green") == 1
-        assert var.get_key("blue") == 2
-
-    def test_get_key_invalid_label(self):
-        var = EnumVariable(name="test", options={0: "red", 1: "green", 2: "blue"})
-        with pytest.raises(ValueError, match="Label 'yellow' not found"):
-            var.get_key("yellow")

--- a/lume/variables/enum.py
+++ b/lume/variables/enum.py
@@ -1,45 +1,32 @@
 import warnings
+from typing import Any
 from pydantic import field_validator, model_validator
 
 from lume.variables.variable import Variable, ConfigEnum
 
 
 class EnumVariable(Variable):
-    """Variable for enumerated values with integer-to-string mapping.
-
-    Similar to EPICS mbbi/mbbo records, this variable allows arbitrary
-    integer values to be associated with string labels.
+    """Variable for enumerated values.
 
     Attributes
     ----------
-    default_value : int | str | None
-        Default value for the variable. Can be an integer key or string value.
-    options : dict[int, str]
-        Mapping of integer values to string labels.
+    default_value : Any | None
+        Default value for the variable. Must be one of the allowed options.
+    options : list[Any]
+        List of allowed values for this variable.
     """
 
-    default_value: int | str | None = None
-    options: dict[int, str]
+    default_value: Any | None = None
+    options: list[Any]
 
     @field_validator("options", mode="before")
     @classmethod
     def validate_options(cls, value):
         if not value:
             raise ValueError("options must not be empty.")
-        if not isinstance(value, dict):
-            raise ValueError(
-                "options must be a dictionary mapping integers to strings."
-            )
-        for key, val in value.items():
-            if not isinstance(key, int):
-                raise ValueError(
-                    f"All option keys must be integers, got {type(key).__name__}: {key}."
-                )
-            if not isinstance(val, str):
-                raise ValueError(
-                    f"All option values must be strings, got {type(val).__name__}: {val}."
-                )
-        return value
+        if not isinstance(value, (list, tuple)):
+            raise ValueError("options must be a list or tuple.")
+        return list(value)
 
     @model_validator(mode="after")
     def validate_default_value(self):
@@ -47,13 +34,13 @@ class EnumVariable(Variable):
             self.validate_value(self.default_value, ConfigEnum.ERROR)
         return self
 
-    def validate_value(self, value: int | str, config: ConfigEnum = None):
+    def validate_value(self, value: Any, config: ConfigEnum = None):
         """Validates the given value.
 
         Parameters
         ----------
-        value : int | str
-            The value to be validated. Can be an integer key or string label.
+        value : Any
+            The value to be validated.
         config : ConfigEnum, optional
             The configuration for validation. Defaults to None.
             Allowed values are "none", "warn", and "error".
@@ -61,36 +48,20 @@ class EnumVariable(Variable):
         Raises
         ------
         TypeError
-            If the value is not an int or str.
+            If the value type does not match the option types.
         ValueError
-            If the value is not a valid key or label in the options mapping.
+            If the value is not in the list of allowed options.
 
         """
         # mandatory validation
-        self._validate_value_type(value)
+        self._validate_value_is_in_options(value, config=config)
 
-        # optional validation
-        config = self._validation_config_as_enum(config)
-
-        if config != ConfigEnum.NULL:
-            self._validate_value_is_in_options(value, config=config)
-
-    @staticmethod
-    def _validate_value_type(value: int | str):
-        """Validate that value is int or str."""
-        if not isinstance(value, (int, str)):
-            raise TypeError(
-                f"Expected value to be int or str, but received {type(value).__name__}."
-            )
-
-    def _validate_value_is_in_options(
-        self, value: int | str, config: ConfigEnum = None
-    ):
-        """Validate that value is a valid key or label in the options mapping.
+    def _validate_value_is_in_options(self, value: Any, config: ConfigEnum = None):
+        """Validate that value is one of the allowed options.
 
         Parameters
         ----------
-        value : int | str
+        value : Any
             The value to validate.
         config : ConfigEnum, optional
             The configuration for validation. Defaults to None.
@@ -98,63 +69,13 @@ class EnumVariable(Variable):
         Raises
         ------
         ValueError
-            If the value is not a valid key or label.
+            If the value is not in the list of allowed options.
         """
         config = self._validation_config_as_enum(config)
 
-        valid_key = isinstance(value, int) and value in self.options
-        valid_label = isinstance(value, str) and value in self.options.values()
-
-        if not (valid_key or valid_label):
-            error_message = (
-                f"Value '{value}' of '{self.name}' is not a valid key or label. "
-                f"Valid keys: {list(self.options.keys())}, "
-                f"Valid labels: {list(self.options.values())}."
-            )
+        if value not in self.options:
+            error_message = f"Value '{value}' of '{self.name}' is not one of the allowed options: {self.options}."
             if config == ConfigEnum.WARN:
                 warnings.warn(error_message)
             else:
                 raise ValueError(error_message)
-
-    def get_label(self, key: int) -> str:
-        """Get the string label for an integer key.
-
-        Parameters
-        ----------
-        key : int
-            The integer key.
-
-        Returns
-        -------
-        str
-            The corresponding string label.
-
-        Raises
-        ------
-        KeyError
-            If the key does not exist in the mapping.
-        """
-        return self.options[key]
-
-    def get_key(self, label: str) -> int:
-        """Get the integer key for a string label.
-
-        Parameters
-        ----------
-        label : str
-            The string label.
-
-        Returns
-        -------
-        int
-            The corresponding integer key.
-
-        Raises
-        ------
-        ValueError
-            If the label does not exist in the mapping.
-        """
-        for key, val in self.options.items():
-            if val == label:
-                return key
-        raise ValueError(f"Label '{label}' not found in options mapping.")


### PR DESCRIPTION
This pull request refactors the `EnumVariable` class and its tests to simplify and generalize how enumerated options are handled. The main change is moving from a dictionary-based mapping of integer keys to string labels to a more flexible list-based approach, allowing any type of value as an option. The tests and validation logic are updated accordingly.

**Core changes to enum variable handling:**

* Refactored `EnumVariable` to accept a list (or tuple) of allowed values for `options` instead of a dictionary mapping integers to strings, making it more flexible and supporting any value type. (`lume/variables/enum.py`, [lume/variables/enum.pyR2-L160](diffhunk://#diff-07621790eea1b4729f2d73031c68a51d68a92cec5a12331f2767851f8ed938eaR2-L160))
* Updated validation logic so that values are checked for membership in the `options` list, rather than being a valid key or label in a dictionary. (`lume/variables/enum.py`, [lume/variables/enum.pyR2-L160](diffhunk://#diff-07621790eea1b4729f2d73031c68a51d68a92cec5a12331f2767851f8ed938eaR2-L160))
* Removed the `get_label` and `get_key` methods, as the mapping between keys and labels is no longer relevant. (`lume/variables/enum.py`, [lume/variables/enum.pyR2-L160](diffhunk://#diff-07621790eea1b4729f2d73031c68a51d68a92cec5a12331f2767851f8ed938eaR2-L160))

**Test suite updates:**

* Rewrote and simplified tests in `test_enum.py` to match the new list-based approach, including tests for option validation, default values, and value validation for various types. (`lume/tests/variables/test_enum.py`, [lume/tests/variables/test_enum.pyL13-L138](diffhunk://#diff-4d01f54922755b94c48110e28a426b9b547ea8c4907d8ce18bd87a4bc5bae293L13-L138))
* Removed tests related to dictionary-based options and key/label lookups, and added tests to cover mixed-type and non-string/non-integer options. (`lume/tests/variables/test_enum.py`, [lume/tests/variables/test_enum.pyL13-L138](diffhunk://#diff-4d01f54922755b94c48110e28a426b9b547ea8c4907d8ce18bd87a4bc5bae293L13-L138))