### PR TITLE
Python 3.10 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/lume/variables/ndvariable.py
+++ b/lume/variables/ndvariable.py
@@ -9,7 +9,7 @@ array_type, dtype, and dtype_attribute.
 """
 
 import typing
-from typing import Any, ClassVar, List, Optional, Self, Tuple
+from typing import Any, ClassVar, List, Optional, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -302,7 +302,7 @@ class NDVariable(Variable):
                 raise ValueError(f"Expected shape {expected_shape}, got {actual_shape}")
 
     @model_validator(mode="after")
-    def validate_default_value(self) -> Self:
+    def validate_default_value(self) -> "NDVariable":
         """Validate the default_value if provided.
 
         Returns

--- a/lume/variables/variable.py
+++ b/lume/variables/variable.py
@@ -6,13 +6,13 @@ but they can be used to validate encountered values.
 """
 
 from abc import ABC, abstractmethod
-from enum import StrEnum
+from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
 
-class ConfigEnum(StrEnum):
+class ConfigEnum(str, Enum):
     """Enum for configuration options during validation."""
 
     NULL = "none"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "lume-base"
 dynamic = ["version"]
 description = "Base classes and architecture for LUME Python projects"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 authors = [
     {name = "SLAC National Accelerator Laboratory"}


### PR DESCRIPTION
This PR allows python 3.10 which isn't yet end of life. Previous comments in PRs ([here](https://github.com/slaclab/lume-base/pull/26)) suggest that this may cause test failures, so investigating that here.

I resolved the following issues on python 3.10:
- No `StrEnum` type. Use the equivalent type `EnumName(str, Enum)`.
- No `typing.Self`. Use the older quoted syntax.