### PR TITLE
Fix packaging issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies and package
         run: |
-          uv sync --extra dev
+          uv sync --extra dev --no-editable
       - name: List Python package versions
         run: uv pip list
       - name: Run tests
         run: |
-          uv run pytest
+          uv run --no-editable pytest --pyargs lume.tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,5 +29,6 @@ jobs:
       - name: List Python package versions
         run: uv pip list
       - name: Run tests
+        working-directory: ${{ runner.temp }}
         run: |
-          uv run --no-editable pytest --pyargs lume.tests
+          uv run --project ${{ github.workspace }} --no-sync pytest --pyargs lume.tests

--- a/lume/tests/test_staged_model.py
+++ b/lume/tests/test_staged_model.py
@@ -2,7 +2,11 @@ from typing import Any
 
 import numpy as np
 import pytest
-from pmd_beamphysics import ParticleGroup
+
+try:
+    from beamphysics import ParticleGroup
+except ImportError:
+    from pmd_beamphysics import ParticleGroup
 
 from lume.model import LUMEModel
 from lume.staged_model import FinalParticlesMixIn, InitialParticlesMixIn, StagedModel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,14 @@ dynamic = ["version"]
 description = "Base classes and architecture for LUME Python projects"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [
     {name = "SLAC National Accelerator Laboratory"}
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,26 +10,18 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
-authors = [
-    {name = "SLAC National Accelerator Laboratory"}
-]
+authors = [{ name = "SLAC National Accelerator Laboratory" }]
 classifiers = [
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Science/Research",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
-    "Topic :: Scientific/Engineering",
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Science/Research",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Scientific/Engineering",
 ]
-dependencies = [
-    "numpy",
-    "openpmd-beamphysics",
-    "h5py",
-    "pyyaml",
-    "pydantic",
-]
+dependencies = ["numpy", "openpmd-beamphysics", "h5py", "pyyaml", "pydantic"]
 
 [project.urls]
 Homepage = "https://github.com/slaclab/lume-base"
@@ -37,23 +29,19 @@ Repository = "https://github.com/slaclab/lume-base"
 Documentation = "https://slaclab.github.io/lume-base"
 
 [project.optional-dependencies]
-dev = [
-    "pytest",
-    "ipykernel",
-    "pre-commit"
-]
+dev = ["pytest", "ipykernel", "pre-commit"]
 docs = [
-    "pygments",
-    "mkdocs",
-    "mkdocstrings",
-    "mkdocstrings-python",
-    "mkdocs-material",
-    "livereload",
-    "pytkdocs[numpy-style]",
+  "pygments",
+  "mkdocs",
+  "mkdocstrings",
+  "mkdocstrings-python",
+  "mkdocs-material",
+  "livereload",
+  "pytkdocs[numpy-style]",
 ]
 
 [tool.setuptools.packages.find]
-where = ["src"]
+where = ["lume*"]
 namespaces = false
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,9 @@ docs = [
     "pytkdocs[numpy-style]",
 ]
 
-[tool.setuptools]
-packages = ["lume", "lume.parsers", "lume.serializers"]
+[tool.setuptools.packages.find]
+where = ["src"]
+namespaces = false
 
 [tool.setuptools.package-data]
 lume = ["py.typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ docs = [
 ]
 
 [tool.setuptools.packages.find]
-where = ["lume*"]
+include = ["lume*"]
 namespaces = false
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
## Changes

* ~Moved the `lume` package from the project root into the `src` directory, updating all references I could find~
   * This is good practice but apparently not what the maintainers want
* The main branch is missing `lume.variables` notably, which means that release v0.4.0 and v0.4.1 are broken on pypi/conda-forge
   * To avoid that in the future, I updated the `pyproject.toml` configuration to use `tool.setuptools.packages.find` instead of a hardcoded list