### PR TITLE
BLD/FIX: git archival for setuptools-scm

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$


### PR DESCRIPTION
## Changes

* Fixes setuptools-scm step missing from initial config for proper archived version information
   * conda-forge relies on this to be able to detect the version directly from the tarball it downloads

For future reference, it's:

```
$ setuptools-scm create-archival-file --stable
Creating stable .git_archival.txt (recommended for releases)
Created: .git_archival.txt

Next steps:
1. Add this line to .gitattributes:
   .git_archival.txt  export-subst
2. Commit both files:
   git add .git_archival.txt .gitattributes
   git commit -m 'add git archive support'
$ git add .git_archival.txt .gitattributes
```
