### PR TITLE
MNT: allow np.integer in `ScalarVariable`, `IntVariable` is now a subclass of `ScalarVariable`

### DIFF
--- a/lume/tests/variables/test_scalar.py
+++ b/lume/tests/variables/test_scalar.py
@@ -46,6 +46,7 @@ class TestScalarVariable:
         var.validate_value(5.0)
         var.validate_value(5)
         var.validate_value(np.float64(5.0))
+        var.validate_value(np.int64(5))
 
     def test_reject_non_numeric_types(self):
         """Test validation rejects non-numeric values."""

--- a/lume/variables/int.py
+++ b/lume/variables/int.py
@@ -1,11 +1,15 @@
+from typing import TypeVar, Union
+
 from pydantic import field_validator, model_validator
 import numpy as np
-import warnings
 
-from lume.variables.variable import Variable, ConfigEnum
+from lume.variables.scalar import ScalarVariable
+
+IntT = TypeVar("IntT", bound=Union[int, np.integer])
+IntType = Union[int, np.integer]  # for isinstance type
 
 
-class IntVariable(Variable):
+class IntVariable(ScalarVariable[IntT]):
     """Variable for int values.
 
     Attributes
@@ -22,79 +26,9 @@ class IntVariable(Variable):
     value_range: tuple[int, int] | None = None
     unit: str | None = None
 
-    @field_validator("value_range", mode="before")
-    @classmethod
-    def validate_value_range(cls, value):
-        if value is not None:
-            value = tuple(value)
-            if not value[0] <= value[1]:
-                raise ValueError(
-                    f"Minimum value ({value[0]}) must be lower or equal than maximum ({value[1]})."
-                )
-        return value
-
-    @model_validator(mode="after")
-    def validate_default_value(self):
-        if self.default_value is not None:
-            self.validate_value(self.default_value, ConfigEnum.ERROR)
-        return self
-
-    def validate_value(self, value: int, config: ConfigEnum = None):
-        """Validates the given value.
-
-        Parameters
-        ----------
-        value : int
-            The value to be validated.
-        config : ConfigEnum, optional
-            The configuration for validation. Defaults to None.
-            Allowed values are "none", "warn", and "error".
-
-        Raises
-        ------
-        TypeError
-            If the value is not of type int.
-        ValueError
-            If the value is out of the valid range or does not match the default value
-            for constant variables.
-
-        """
-        # mandatory validation
-        self._validate_value_type(value)
-
-        # optional validation
-        config = self._validation_config_as_enum(config)
-
-        if config != ConfigEnum.NULL:
-            self._validate_value_is_within_range(value, config=config)
-
     @staticmethod
-    def _validate_value_type(value: int):
-        if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+    def _validate_value_type(value: IntT):
+        if isinstance(value, bool) or not isinstance(value, IntType):
             raise TypeError(
-                f"Expected value to be of type {int} or {np.integer}, but received {type(value)}."
+                f"Expected value to be of type {IntType}, but received {type(value)}."
             )
-
-    def _validate_value_is_within_range(self, value: int, config: ConfigEnum = None):
-        config = self._validation_config_as_enum(config)
-
-        if not self._value_is_within_range(value):
-            error_message = (
-                "Value ({}) of '{}' is out of valid range: ([{},{}]).".format(
-                    value, self.name, *self.value_range
-                )
-            )
-            range_warning_message = (
-                error_message
-                + " Executing the model outside of the range may result in"
-                " unpredictable and invalid predictions."
-            )
-            if config == ConfigEnum.WARN:
-                warnings.warn(range_warning_message)
-            else:
-                raise ValueError(error_message)
-
-    def _value_is_within_range(self, value) -> bool:
-        if self.value_range is not None:
-            return self.value_range[0] <= value <= self.value_range[1]
-        return True

--- a/lume/variables/int.py
+++ b/lume/variables/int.py
@@ -5,8 +5,8 @@ import numpy as np
 
 from lume.variables.scalar import ScalarVariable
 
-IntT = TypeVar("IntT", bound=Union[int, np.integer])
-IntType = Union[int, np.integer]  # for isinstance type
+IntType = int | np.integer  # for isinstance type
+IntT = TypeVar("IntT", bound=IntType)
 
 
 class IntVariable(ScalarVariable[IntT]):

--- a/lume/variables/int.py
+++ b/lume/variables/int.py
@@ -1,6 +1,5 @@
-from typing import TypeVar, Union
+from typing import TypeVar
 
-from pydantic import field_validator, model_validator
 import numpy as np
 
 from lume.variables.scalar import ScalarVariable

--- a/lume/variables/scalar.py
+++ b/lume/variables/scalar.py
@@ -81,9 +81,11 @@ class ScalarVariable(Variable, Generic[ScalarT]):
                 f"Expected value to be of type {ScalarType} or bool, but received {type(value)}."
             )
 
-    def _validate_value_is_within_range(self, value: ScalarT, config: ConfigEnum | None = None):
+    def _validate_value_is_within_range(
+        self, value: ScalarT, config: ConfigEnum | None = None
+    ):
         config = self._validation_config_as_enum(config)
-    
+
         if not self._value_is_within_range(value):
             error_message = (
                 "Value ({}) of '{}' is out of valid range: ([{},{}]).".format(

--- a/lume/variables/scalar.py
+++ b/lume/variables/scalar.py
@@ -6,6 +6,9 @@ from pydantic import field_validator, model_validator
 from lume.variables.variable import Variable, ConfigEnum
 
 
+ScalarType = float | int | np.floating | np.integer
+
+
 class ScalarVariable(Variable):
     """Variable for float values.
 
@@ -70,15 +73,15 @@ class ScalarVariable(Variable):
             self._validate_value_is_within_range(value, config=config)
 
     @staticmethod
-    def _validate_value_type(value: float):
-        if not isinstance(value, (int, float, np.floating)) or isinstance(value, bool):
+    def _validate_value_type(value: ScalarType):
+        if not isinstance(value, ScalarType) or isinstance(value, bool):
             raise TypeError(
-                f"Expected value to be of type {float} or {np.float64}, but received {type(value)}."
+                f"Expected value to be of type {ScalarType} or bool, but received {type(value)}."
             )
 
     def _validate_value_is_within_range(self, value: float, config: ConfigEnum = None):
         config = self._validation_config_as_enum(config)
-
+    
         if not self._value_is_within_range(value):
             error_message = (
                 "Value ({}) of '{}' is out of valid range: ([{},{}]).".format(

--- a/lume/variables/scalar.py
+++ b/lume/variables/scalar.py
@@ -1,4 +1,4 @@
-from typing import Generic, TypeVar, Union
+from typing import Generic, TypeVar
 import warnings
 
 import numpy as np
@@ -7,8 +7,8 @@ from pydantic import field_validator, model_validator
 from lume.variables.variable import Variable, ConfigEnum
 
 
-ScalarT = TypeVar("ScalarT", bound=Union[float, int, np.floating, np.integer])
-ScalarType = Union[float, int, np.floating, np.integer]  # for isinstance type
+ScalarType = float | int | np.floating | np.integer  # for isinstance type
+ScalarT = TypeVar("ScalarT", bound=ScalarType)
 
 
 class ScalarVariable(Variable, Generic[ScalarT]):
@@ -45,7 +45,7 @@ class ScalarVariable(Variable, Generic[ScalarT]):
             self.validate_value(self.default_value, ConfigEnum.ERROR)
         return self
 
-    def validate_value(self, value: ScalarT, config: ConfigEnum = None):
+    def validate_value(self, value: ScalarT, config: ConfigEnum | None = None):
         """Validates the given value.
 
         Parameters
@@ -81,7 +81,7 @@ class ScalarVariable(Variable, Generic[ScalarT]):
                 f"Expected value to be of type {ScalarType} or bool, but received {type(value)}."
             )
 
-    def _validate_value_is_within_range(self, value: ScalarT, config: ConfigEnum = None):
+    def _validate_value_is_within_range(self, value: ScalarT, config: ConfigEnum | None = None):
         config = self._validation_config_as_enum(config)
     
         if not self._value_is_within_range(value):

--- a/lume/variables/scalar.py
+++ b/lume/variables/scalar.py
@@ -1,3 +1,4 @@
+from typing import Generic, TypeVar, Union
 import warnings
 
 import numpy as np
@@ -6,10 +7,11 @@ from pydantic import field_validator, model_validator
 from lume.variables.variable import Variable, ConfigEnum
 
 
-ScalarType = float | int | np.floating | np.integer
+ScalarT = TypeVar("ScalarT", bound=Union[float, int, np.floating, np.integer])
+ScalarType = Union[float, int, np.floating, np.integer]  # for isinstance type
 
 
-class ScalarVariable(Variable):
+class ScalarVariable(Variable, Generic[ScalarT]):
     """Variable for float values.
 
     Attributes
@@ -43,12 +45,12 @@ class ScalarVariable(Variable):
             self.validate_value(self.default_value, ConfigEnum.ERROR)
         return self
 
-    def validate_value(self, value: float, config: ConfigEnum = None):
+    def validate_value(self, value: ScalarT, config: ConfigEnum = None):
         """Validates the given value.
 
         Parameters
         ----------
-        value : float
+        value : float | int | np.floating | np.integer
             The value to be validated.
         config : ConfigEnum, optional
             The configuration for validation. Defaults to None.
@@ -73,13 +75,13 @@ class ScalarVariable(Variable):
             self._validate_value_is_within_range(value, config=config)
 
     @staticmethod
-    def _validate_value_type(value: ScalarType):
+    def _validate_value_type(value: ScalarT):
         if not isinstance(value, ScalarType) or isinstance(value, bool):
             raise TypeError(
                 f"Expected value to be of type {ScalarType} or bool, but received {type(value)}."
             )
 
-    def _validate_value_is_within_range(self, value: float, config: ConfigEnum = None):
+    def _validate_value_is_within_range(self, value: ScalarT, config: ConfigEnum = None):
         config = self._validation_config_as_enum(config)
     
         if not self._value_is_within_range(value):


### PR DESCRIPTION
## Description
- Allows `np.integer` in `ScalarVariable.validate_value`
  - This method already allowed vanilla `int`, and this was a natural extension
  - Updates tests to account for this case
- Makes `IntegerVariable` a subclass of `ScalarVariable`, reducing duplication
  - Uses bounded Generics to type hint this (`ScalarT`, `IntT`, etc)
  - The classes had already de-synced on `. _value_is_within_range`
- Attempts to reduce type-hinting errors where minimally invasive

## Context
In running lume-impact, we were getting values that were `np.int`, causing errors in validation

I didn't change the base pydantic field type hints, as that might actually constitute an API break.  Perhaps we want to coerce / cast values in the future?  (wink wink nudge nudge)

```python
>>> from lume.variables.int import IntVariable
>>> from lume.variables.scalar import ScalarType, ScalarVariable
>>> import numpy as np

>>> ScalarVariable(name='my_var').validate_value(np.int64(2))
>>> ScalarVariable(name='my_var').validate_value('notanum')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/rtangkong/devrepos/lume-base/lume/variables/scalar.py", line 69, in validate_value
    self._validate_value_type(value)
  File "/Users/rtangkong/devrepos/lume-base/lume/variables/scalar.py", line 80, in _validate_value_type
    raise TypeError(
TypeError: Expected value to be of type float | int | numpy.floating | numpy.integer or bool, but received <class 'str'>.

>>> IntVariable(name="my_int").validate_value(2)
>>> IntVariable(name="my_int").validate_value('f')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/rtangkong/devrepos/lume-base/lume/variables/scalar.py", line 69, in validate_value
    self._validate_value_type(value)
  File "/Users/rtangkong/devrepos/lume-base/lume/variables/int.py", line 32, in _validate_value_type
    raise TypeError(
TypeError: Expected value to be of type int | numpy.integer, but received <class 'str'>.
```