### PR TITLE
Actions Framework

### DIFF
--- a/docs/examples/lume_model_actions.ipynb
+++ b/docs/examples/lume_model_actions.ipynb
@@ -1,0 +1,495 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "50671e8e",
+   "metadata": {},
+   "source": [
+    "# LUME Model Actions Framework\n",
+    "\n",
+    "The LUME Model interface defines a common way of exposing a calculation or simulation with state through readable / writable variables.\n",
+    "A common use case is to expose an existing simulation tool wrapped by LUME or other python libraries to control systems.\n",
+    "To make this application easeier, `lume-base` includes the \"actions framework\" for models.\n",
+    "\n",
+    "In this framework, the `Variable` objects are extended with an additional `.get(...)` and `.set(...)` method that acts on a simulator tool.\n",
+    "These extended variables also include any parameters needed to talk to the simulator such as the names of elements and attributes, or scaling factors.\n",
+    "We call these \"actions\".\n",
+    "The actions may be inserted into a special LUME model called `ActionModel` which handles the model's get, set, and supported variables methods. \n",
+    "Defining parameterized actions which define broad classes of what you \"can do\" to the simulator object encourages maintainable, readable code and ensures a model with consistency between the supported variables list and the things the model is able to do."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b12b72df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lume.actions import Action, ActionModel\n",
+    "from lume.variables import ScalarVariable\n",
+    "from typing import Any"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83321a49",
+   "metadata": {},
+   "source": [
+    "## Mock Simulator Object\n",
+    "First, we need to define a simulator object. In practice, this would be a LUME object such as `Impact` or `Genesis`. \n",
+    "Here, we show a simulator tool with a dict of elements which are each a dict of attributes and their values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0b64efe2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Simulator:\n",
+    "    \"\"\"A mockup of a simulation tool (ie Impact, GPT, Genesis)\"\"\"\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        self.ele = {\n",
+    "            \"SOL1\": {\"length\": 1.0, \"current\": 0.5},\n",
+    "            \"CAV1\": {\"phase0\": 0.0, \"voltage\": 10.0},\n",
+    "        }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70cfe937",
+   "metadata": {},
+   "source": [
+    "## Example Action\n",
+    "Here, we make our first action.\n",
+    "This action sets or gets any of the float attributes in the element dict.\n",
+    "It is parameterized by the element name and attribute name allowing the same code to be reused for any of the elements in the simulator.\n",
+    "Which one it talks to is determined by the value of `ele_name` and `attribute_name` set when the variable is created."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2f0bc0c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class EleActionVariable(ScalarVariable, Action[Simulator]):\n",
+    "    \"\"\"\n",
+    "    This variable sets and gets the value in the elements dict of `simulator` with the given element and attribute name.\n",
+    "\n",
+    "    This could, for example, be used to set and get paramters of beamline elements in an accelerator simulation code.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    # Action variables are still pydantic objects since they are variables\n",
+    "    # We can store data in them to parameterize the set and get function\n",
+    "    ele_name: str\n",
+    "    attribute_name: str\n",
+    "\n",
+    "    # Action variable stores both method to \"talk to\" simulator and the data needed to parameterize it\n",
+    "    def _get(self, simulator: Simulator) -> float:\n",
+    "        return simulator.ele[self.ele_name][self.attribute_name]\n",
+    "\n",
+    "    def _set(self, simulator: Simulator, value: Any) -> float:\n",
+    "        simulator.ele[self.ele_name][self.attribute_name] = value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "973cde4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a variable action which sets SOL1's current. Remember, it is a variable and we must define all of the variable's\n",
+    "# fields (such as variable name) as well as the ones that parameterize the action\n",
+    "sol_action = EleActionVariable(\n",
+    "    name=\"INJECTOR:SOL1:CURRENT\",  # The variable's name\n",
+    "    value_range=(0.0, 1.0),  # [optional] The variable's range\n",
+    "    unit=\"kA\",  # [optional] Units associated with the variable\n",
+    "    ele_name=\"SOL1\",  # The action's parameter. The name of the element in the simulator\n",
+    "    attribute_name=\"current\",  # Another action parameter. The name of the attribute internally\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "693f98eb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solenoid Current: 0.5 kA\n",
+      "Solenoid Current: 0.25 kA\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Use the action to change settings in the simulator\n",
+    "sim = Simulator()\n",
+    "\n",
+    "# Get the current\n",
+    "cur = sol_action._get(sim)\n",
+    "print(\"Solenoid Current: {:.2} kA\".format(cur))\n",
+    "\n",
+    "# Set it lower and print the current afterwards\n",
+    "sol_action._set(sim, 0.25)\n",
+    "cur = sol_action._get(sim)\n",
+    "print(\"Solenoid Current: {:.2} kA\".format(cur))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9389d695",
+   "metadata": {},
+   "source": [
+    "## Actions Model\n",
+    "Now, we will create a model from several actions.\n",
+    "We will create actions that expose all of the elements and attributes inside of the simulator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "70c0a7ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "actions = [\n",
+    "    EleActionVariable(\n",
+    "        name=\"INJECTOR:SOL1:CURRENT\",\n",
+    "        unit=\"kA\",\n",
+    "        ele_name=\"SOL1\",\n",
+    "        attribute_name=\"current\",\n",
+    "    ),\n",
+    "    EleActionVariable(\n",
+    "        name=\"INJECTOR:SOL1:LENGTH\",\n",
+    "        unit=\"kA\",\n",
+    "        ele_name=\"SOL1\",\n",
+    "        attribute_name=\"length\",\n",
+    "    ),\n",
+    "    EleActionVariable(\n",
+    "        name=\"INJECTOR:CAV1:PHASE\",\n",
+    "        unit=\"1/2/pi\",\n",
+    "        ele_name=\"CAV1\",\n",
+    "        attribute_name=\"phase0\",\n",
+    "    ),\n",
+    "    EleActionVariable(\n",
+    "        name=\"INJECTOR:CAV1:VOLTAGE\",\n",
+    "        unit=\"kV\",\n",
+    "        ele_name=\"CAV1\",\n",
+    "        attribute_name=\"voltage\",\n",
+    "    ),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "3a786b8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make a fresh simulator object for the model\n",
+    "sim = Simulator()\n",
+    "\n",
+    "# Construct a model from the actions\n",
+    "# It contains the simulator object and the action variables\n",
+    "model = ActionModel(simulator=sim, action_variables=actions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "401886c3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'INJECTOR:SOL1:CURRENT': 0.5,\n",
+       " 'INJECTOR:SOL1:LENGTH': 1.0,\n",
+       " 'INJECTOR:CAV1:PHASE': 0.0,\n",
+       " 'INJECTOR:CAV1:VOLTAGE': 10.0}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get all values from the simulator\n",
+    "model.get(\n",
+    "    [\n",
+    "        \"INJECTOR:SOL1:CURRENT\",\n",
+    "        \"INJECTOR:SOL1:LENGTH\",\n",
+    "        \"INJECTOR:CAV1:PHASE\",\n",
+    "        \"INJECTOR:CAV1:VOLTAGE\",\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "eedfd51c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'INJECTOR:SOL1:CURRENT': 0.5,\n",
+       " 'INJECTOR:SOL1:LENGTH': 1.0,\n",
+       " 'INJECTOR:CAV1:PHASE': 0.0,\n",
+       " 'INJECTOR:CAV1:VOLTAGE': 0.0}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Turn off the cavity\n",
+    "model.set({\"INJECTOR:CAV1:VOLTAGE\": 0.0})\n",
+    "model.get(\n",
+    "    [\n",
+    "        \"INJECTOR:SOL1:CURRENT\",\n",
+    "        \"INJECTOR:SOL1:LENGTH\",\n",
+    "        \"INJECTOR:CAV1:PHASE\",\n",
+    "        \"INJECTOR:CAV1:VOLTAGE\",\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9eba0e82",
+   "metadata": {},
+   "source": [
+    "## Move Advanced Action Example\n",
+    "Actions contain arbitrary python code and can do more than simply setting and getting attributes.\n",
+    "Applications include, for example, scaling units, unit calibration, composite variables (consisting of setting/getting more than one attribute in the tool)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "4b43e270",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class FieldIntegralVariable(ScalarVariable, Action[Simulator]):\n",
+    "    \"\"\"\n",
+    "    This action demonstrates a variable which involves more than one attribute. In this case, an integrated field.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    # The name of the element we act on\n",
+    "    ele_name: str\n",
+    "    cur_to_field: float = (\n",
+    "        1.0  # A conversion factor from current * length to integrated field\n",
+    "    )\n",
+    "\n",
+    "    # Action variable stores both method to \"talk to\" simulator and the data needed to parameterize it\n",
+    "    def _get(self, simulator: Simulator) -> float:\n",
+    "        magnet_length = simulator.ele[self.ele_name][\"length\"]\n",
+    "        magnet_current = simulator.ele[self.ele_name][\"current\"]\n",
+    "        return magnet_length * magnet_current * self.cur_to_field\n",
+    "\n",
+    "    def _set(self, simulator: Simulator, value: Any) -> float:\n",
+    "        magnet_length = simulator.ele[self.ele_name][\"length\"]\n",
+    "        magnet_current = value / magnet_length / self.cur_to_field\n",
+    "        simulator.ele[self.ele_name][\"current\"] = magnet_current"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "9e0ca22b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ScaledEleAction(ScalarVariable, Action[Simulator]):\n",
+    "    \"\"\"\n",
+    "    This action controls an attribute for an element with a linear transformation which can be used for model\n",
+    "    calibration or for unit conversion.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    # The element name and attribute the control variable acts on\n",
+    "    ele_name: str\n",
+    "    attribute_name: str\n",
+    "\n",
+    "    # Define a linear transformation mapping simulation units to control system units\n",
+    "    scale: float\n",
+    "    offset: float\n",
+    "\n",
+    "    def _get(self, simulator):\n",
+    "        return (\n",
+    "            self.scale * simulator.ele[self.ele_name][self.attribute_name] + self.offset\n",
+    "        )\n",
+    "\n",
+    "    def _set(self, simulator, value):\n",
+    "        simulator.ele[self.ele_name][self.attribute_name] = (\n",
+    "            value - self.offset\n",
+    "        ) / self.scale"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0f29a10",
+   "metadata": {},
+   "source": [
+    "## Adding Actions to a Model\n",
+    "Actions can be added to the model after it is created allowing you to write or use other's code that generates a basic model from your simulation tool and then add additional actions customized for your situation. We demonstrate this by adding our new actions to the existing model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "5676f592",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The composite field integral variable on the solenoid element\n",
+    "var = FieldIntegralVariable(name=\"INJECTOR:SOL1:INTEGRATED_FIELD\", ele_name=\"SOL1\")\n",
+    "model.register_action_variable(var)\n",
+    "\n",
+    "# A scaled version of the phase\n",
+    "var = ScaledEleAction(\n",
+    "    name=\"INJECTOR:CAV1:PHASE_DEG\",\n",
+    "    ele_name=\"CAV1\",\n",
+    "    attribute_name=\"phase0\",\n",
+    "    scale=360.0,\n",
+    "    offset=0.0,\n",
+    ")\n",
+    "model.register_action_variable(var)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "f61d668f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'INJECTOR:SOL1:INTEGRATED_FIELD': 0.5,\n",
+       " 'INJECTOR:SOL1:CURRENT': 0.5,\n",
+       " 'INJECTOR:CAV1:PHASE_DEG': 0.0,\n",
+       " 'INJECTOR:CAV1:PHASE': 0.0}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get the values\n",
+    "model.get(\n",
+    "    [\n",
+    "        \"INJECTOR:SOL1:INTEGRATED_FIELD\",\n",
+    "        \"INJECTOR:SOL1:CURRENT\",\n",
+    "        \"INJECTOR:CAV1:PHASE_DEG\",\n",
+    "        \"INJECTOR:CAV1:PHASE\",\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "c834d882",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'INJECTOR:SOL1:INTEGRATED_FIELD': 0.75,\n",
+       " 'INJECTOR:SOL1:CURRENT': 0.75,\n",
+       " 'INJECTOR:CAV1:PHASE_DEG': 180.0,\n",
+       " 'INJECTOR:CAV1:PHASE': 0.5}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Demonstrate setting them\n",
+    "model.set({\"INJECTOR:SOL1:INTEGRATED_FIELD\": 0.75, \"INJECTOR:CAV1:PHASE_DEG\": 180})\n",
+    "model.get(\n",
+    "    [\n",
+    "        \"INJECTOR:SOL1:INTEGRATED_FIELD\",\n",
+    "        \"INJECTOR:SOL1:CURRENT\",\n",
+    "        \"INJECTOR:CAV1:PHASE_DEG\",\n",
+    "        \"INJECTOR:CAV1:PHASE\",\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e0e8808",
+   "metadata": {},
+   "source": [
+    "## Removal of Actions\n",
+    "You may also remove actions by variable name. This can be useful in modifying existing models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d1e4f74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Remove the action\n",
+    "model.unregister_action_variable(\"INJECTOR:SOL1:INTEGRATED_FIELD\")\n",
+    "\n",
+    "# Attempt to access\n",
+    "try:\n",
+    "    model.get([\"INJECTOR:SOL1:INTEGRATED_FIELD\"])\n",
+    "except ValueError as ex:\n",
+    "    print(ex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5427b91",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "lume-impact-dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/lume_model_actions.ipynb
+++ b/docs/examples/lume_model_actions.ipynb
@@ -447,10 +447,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "1d1e4f74",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Variable 'INJECTOR:SOL1:INTEGRATED_FIELD' is not supported by the model.\n"
+     ]
+    }
+   ],
    "source": [
     "# Remove the action\n",
     "model.unregister_action_variable(\"INJECTOR:SOL1:INTEGRATED_FIELD\")\n",

--- a/lume/__init__.py
+++ b/lume/__init__.py
@@ -1,9 +1,10 @@
 from importlib.metadata import PackageNotFoundError, version
 
-from lume.actions import Action, ReadOnlyActionMixin, WritableActionMixin
+from lume.actions import Action, ActionModel, ReadOnlyActionMixin, WritableActionMixin
 
 __all__ = [
     "Action",
+    "ActionModel",
     "ReadOnlyActionMixin",
     "WritableActionMixin",
 ]

--- a/lume/__init__.py
+++ b/lume/__init__.py
@@ -1,5 +1,13 @@
 from importlib.metadata import PackageNotFoundError, version
 
+from lume.actions import Action, ReadOnlyActionMixin, WritableActionMixin
+
+__all__ = [
+    "Action",
+    "ReadOnlyActionMixin",
+    "WritableActionMixin",
+]
+
 try:
     __version__ = version("lume-base")
 except PackageNotFoundError:

--- a/lume/actions.py
+++ b/lume/actions.py
@@ -52,21 +52,6 @@ class ReadOnlyActionMixin(Action[SimulatorT], Generic[SimulatorT]):
         """
         ...
 
-    def get(self, simulator: SimulatorT) -> Any:
-        """Return the current value from ``simulator``. Do not override, put your implementation in _get instead.
-
-        Parameters
-        ----------
-        simulator : SimulatorT
-            The simulator to read from.
-
-        Returns
-        -------
-        Any
-            The current value of this variable in the simulator.
-        """
-        return self._get(simulator)
-
 
 class WritableActionMixin(Action[SimulatorT], Generic[SimulatorT]):
     """Mixin for writable variable-actions.
@@ -107,40 +92,6 @@ class WritableActionMixin(Action[SimulatorT], Generic[SimulatorT]):
         """
         ...
 
-    def get(self, simulator: SimulatorT) -> Any:
-        """Return the current value from ``simulator``. Please override _get instead of this.
-
-        Parameters
-        ----------
-        simulator : SimulatorT
-            The simulator to read from.
-
-        Returns
-        -------
-        Any
-            The current value of this variable in the simulator.
-        """
-        return self._get(simulator)
-
-    def set(self, simulator: SimulatorT, value: Any) -> None:
-        """Write ``value`` to ``simulator``. Please override _set instead of this.
-
-        Parameters
-        ----------
-        simulator : SimulatorT
-            The simulator to write to.
-        value : Any
-            The value to assign to this variable in the simulator.
-
-        Raises
-        ------
-        ReadOnlyError
-            If this variable has ``read_only=True``.
-        """
-        if self.read_only:
-            raise ReadOnlyError(f"'{self.name}' is read-only")
-        self._set(simulator, value)
-
 
 class ActionModel(LUMEModel, Generic[SimulatorT]):
     """LUMEModel backed by a collection of action variables.
@@ -180,7 +131,7 @@ class ActionModel(LUMEModel, Generic[SimulatorT]):
 
     def _get(self, names: list[str]) -> dict[str, Any]:
         return {
-            name: self._action_variable_by_name[name].get(self.simulator)
+            name: self._action_variable_by_name[name]._get(self.simulator)
             for name in names
         }
 
@@ -189,7 +140,7 @@ class ActionModel(LUMEModel, Generic[SimulatorT]):
             self._action_variable_by_name[name]._set(self.simulator, value)
 
     def reset(self) -> None:
-        self.set(
+        self._set(
             {
                 av.name: av.default_value
                 for av in self._action_variable_by_name.values()

--- a/lume/actions.py
+++ b/lume/actions.py
@@ -6,6 +6,8 @@ from typing import Any, Generic, TypeVar
 from pydantic import field_validator
 
 from lume.exceptions import ReadOnlyError
+from lume.model import LUMEModel
+from lume.variables import Variable
 
 SimulatorT = TypeVar("SimulatorT")
 
@@ -138,3 +140,95 @@ class WritableActionMixin(Action[SimulatorT], Generic[SimulatorT]):
         if self.read_only:
             raise ReadOnlyError(f"'{self.name}' is read-only")
         self._set(simulator, value)
+
+
+class ActionModel(LUMEModel, Generic[SimulatorT]):
+    """LUMEModel backed by a collection of action variables.
+
+    Each entry in ``action_variables`` must be an ``Action`` instance (i.e. a
+    ``Variable`` subclass that also mixes in ``ReadOnlyActionMixin`` or
+    ``WritableActionMixin``). The model delegates ``get`` and ``set`` calls to
+    the corresponding action variable.
+
+    Parameters
+    ----------
+    simulator : SimulatorT
+        The simulator object passed through to each action variable's
+        ``get`` / ``set`` implementation.
+    action_variables : list[Variable]
+        The action variables managed by this model.
+
+    Raises
+    ------
+    ValueError
+        If any entry in ``action_variables`` is not an ``Action`` instance.
+    """
+
+    def __init__(
+        self,
+        simulator: SimulatorT,
+        action_variables: list[Variable],
+    ) -> None:
+        self.simulator = simulator
+        self._action_variable_by_name: dict[str, Variable] = {}
+        for av in action_variables:
+            self.register_action_variable(av)
+
+    @property
+    def supported_variables(self) -> dict[str, Variable]:
+        return dict(self._action_variable_by_name)
+
+    def _get(self, names: list[str]) -> dict[str, Any]:
+        return {
+            name: self._action_variable_by_name[name].get(self.simulator)
+            for name in names
+        }
+
+    def _set(self, values: dict[str, Any]) -> None:
+        for name, value in values.items():
+            self._action_variable_by_name[name]._set(self.simulator, value)
+
+    def reset(self) -> None:
+        self.set(
+            {
+                av.name: av.default_value
+                for av in self._action_variable_by_name.values()
+                if isinstance(av, WritableActionMixin) and hasattr(av, "default_value")
+            }
+        )
+
+    def register_action_variable(self, action_variable: Variable) -> None:
+        """Add an action variable to the model, replacing any with the same name.
+
+        Parameters
+        ----------
+        action_variable : Variable
+            The action variable to register. Must be an ``Action`` instance.
+
+        Raises
+        ------
+        ValueError
+            If ``action_variable`` is not an ``Action`` instance.
+        """
+        if not isinstance(action_variable, Action):
+            raise ValueError(
+                f"Expected an Action instance, got {type(action_variable).__name__!r}"
+            )
+        self._action_variable_by_name[action_variable.name] = action_variable
+
+    def unregister_action_variable(self, name: str) -> None:
+        """Remove an action variable from the model by name.
+
+        Parameters
+        ----------
+        name : str
+            Name of the action variable to remove.
+
+        Raises
+        ------
+        KeyError
+            If no action variable with the given name is registered.
+        """
+        if name not in self._action_variable_by_name:
+            raise KeyError(f"No action variable named '{name}' is registered")
+        del self._action_variable_by_name[name]

--- a/lume/actions.py
+++ b/lume/actions.py
@@ -136,7 +136,8 @@ ActionVariable = Union[
 
 
 class ActionModel(LUMEModel, Generic[SimulatorT]):
-    """LUMEModel backed by a collection of action variables.
+    """
+    LUMEModel backed by a collection of action variables.
 
     Each entry in ``action_variables`` must be an ``Action`` instance (i.e. a
     ``Variable`` subclass that also mixes in ``ReadOnlyActionMixin`` or
@@ -148,7 +149,7 @@ class ActionModel(LUMEModel, Generic[SimulatorT]):
     simulator : SimulatorT
         The simulator object passed through to each action variable's
         ``get`` / ``set`` implementation.
-    action_variables : list[Variable]
+    action_variables : list[ActionVariable[SimulatorT]]
         The action variables managed by this model.
 
     Raises
@@ -195,12 +196,14 @@ class ActionModel(LUMEModel, Generic[SimulatorT]):
     def register_action_variable(
         self, action_variable: ActionVariable[SimulatorT]
     ) -> None:
-        """Add an action variable to the model, replacing any with the same name.
+        """
+        Add an action variable to the model, replacing any with the same name.
 
         Parameters
         ----------
-        action_variable : Variable
-            The action variable to register. Must be an ``Action`` instance.
+        action_variable : ActionVariable[SimulatorT]
+            The action variable to register. Ie a class that inherits from both a `Variable`
+            and either `ReadOnlyActionMixin` or `WritableActionMixin`.
 
         Raises
         ------
@@ -214,7 +217,8 @@ class ActionModel(LUMEModel, Generic[SimulatorT]):
         self._action_variable_by_name[action_variable.name] = action_variable
 
     def unregister_action_variable(self, name: str) -> ActionVariable[SimulatorT]:
-        """Remove an action variable from the model by name.
+        """
+        Remove an action variable from the model by name.
 
         Parameters
         ----------

--- a/lume/actions.py
+++ b/lume/actions.py
@@ -102,7 +102,9 @@ class WritableActionMixin(Action[SimulatorT], Generic[SimulatorT]):
 # outside of this module.
 
 
-class ReadOnlyActionVariable(ReadOnlyActionMixin, Variable):
+class ReadOnlyActionVariable(
+    ReadOnlyActionMixin[SimulatorT], Variable, Generic[SimulatorT]
+):
     def __init__(self, *args, **kwargs):
         raise NotImplementedError("This is a type hinting stub")
 
@@ -110,19 +112,23 @@ class ReadOnlyActionVariable(ReadOnlyActionMixin, Variable):
         raise NotImplementedError("This is a type hinting stub")
 
 
-class WritableActionVariable(WritableActionMixin, Variable):
+class WritableActionVariable(
+    WritableActionMixin[SimulatorT], Variable, Generic[SimulatorT]
+):
     def __init__(self, *args, **kwargs):
         raise NotImplementedError("This is a type hinting stub")
 
     def _get(self, simulator: SimulatorT) -> Any:
         raise NotImplementedError("This is a type hinting stub")
 
-    def _set(self, simulator: SimulatorT) -> Any:
+    def _set(self, simulator: SimulatorT, value: Any) -> None:
         raise NotImplementedError("This is a type hinting stub")
 
 
 # Type which will have the correct interface from user-provided variables
-ActionVariable = Union[ReadOnlyActionVariable, WritableActionVariable]
+ActionVariable = Union[
+    ReadOnlyActionVariable[SimulatorT], WritableActionVariable[SimulatorT]
+]
 
 
 ###############################################################################
@@ -154,15 +160,15 @@ class ActionModel(LUMEModel, Generic[SimulatorT]):
     def __init__(
         self,
         simulator: SimulatorT,
-        action_variables: list[ActionVariable],
+        action_variables: list[ActionVariable[SimulatorT]],
     ) -> None:
         self.simulator = simulator
-        self._action_variable_by_name: dict[str, ActionVariable] = {}
+        self._action_variable_by_name: dict[str, ActionVariable[SimulatorT]] = {}
         for av in action_variables:
             self.register_action_variable(av)
 
     @property
-    def supported_variables(self) -> dict[str, ActionVariable]:
+    def supported_variables(self) -> dict[str, ActionVariable[SimulatorT]]:
         return dict(self._action_variable_by_name)
 
     def _get(self, names: list[str]) -> dict[str, Any]:
@@ -173,7 +179,9 @@ class ActionModel(LUMEModel, Generic[SimulatorT]):
 
     def _set(self, values: dict[str, Any]) -> None:
         for name, value in values.items():
-            self._action_variable_by_name[name]._set(self.simulator, value)
+            av = self._action_variable_by_name[name]
+            if isinstance(av, WritableActionMixin):
+                av._set(self.simulator, value)
 
     def reset(self) -> None:
         self._set(
@@ -184,7 +192,9 @@ class ActionModel(LUMEModel, Generic[SimulatorT]):
             }
         )
 
-    def register_action_variable(self, action_variable: ActionVariable) -> None:
+    def register_action_variable(
+        self, action_variable: ActionVariable[SimulatorT]
+    ) -> None:
         """Add an action variable to the model, replacing any with the same name.
 
         Parameters

--- a/lume/actions.py
+++ b/lume/actions.py
@@ -213,13 +213,18 @@ class ActionModel(LUMEModel, Generic[SimulatorT]):
             )
         self._action_variable_by_name[action_variable.name] = action_variable
 
-    def unregister_action_variable(self, name: str) -> None:
+    def unregister_action_variable(self, name: str) -> ActionVariable[SimulatorT]:
         """Remove an action variable from the model by name.
 
         Parameters
         ----------
         name : str
             Name of the action variable to remove.
+
+        Returns
+        -------
+        ActionVariable
+            The removed action variable.
 
         Raises
         ------
@@ -228,4 +233,4 @@ class ActionModel(LUMEModel, Generic[SimulatorT]):
         """
         if name not in self._action_variable_by_name:
             raise KeyError(f"No action variable named '{name}' is registered")
-        del self._action_variable_by_name[name]
+        return self._action_variable_by_name.pop(name)

--- a/lume/actions.py
+++ b/lume/actions.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Generic, TypeVar, Self
+
+from pydantic import BaseModel, model_validator
+
+from lume.variables import Variable
+from lume.exceptions import ReadOnlyError
+
+SimulatorT = TypeVar("SimulatorT")
+
+
+class Action(ABC, BaseModel, Generic[SimulatorT]):
+    """Base for read-only actions over a generic simulator type.
+
+    Subclasses must implement ``_get``.  The ``model_validator`` enforces
+    that the associated variable is marked read-only at construction time.
+    """
+
+    var: Variable
+
+    @property
+    def name(self) -> str:
+        return self.var.name
+
+    @property
+    def read_only(self) -> bool:
+        return getattr(self.var, "read_only")
+
+    @model_validator(mode="after")
+    def _check_var(self) -> "Action[SimulatorT]":
+        if not self.var.read_only:
+            raise ReadOnlyError(f"{type(self).__name__} requires a read-only variable")
+        return self
+
+    @abstractmethod
+    def _get(self, simulator: SimulatorT) -> Any:
+        """
+        The child-class implementation of the get method. Override this method and
+        not `get` for defining the action's functionality.
+
+        Parameters
+        ----------
+        simulator: SimulatorT
+            The simulator object the parameter is pulled from
+        """
+        ...
+
+    def get(self, simulator: SimulatorT) -> Any:
+        """
+        Outside facing get method.
+
+        Parameters
+        ----------
+        simulator: SimulatorT
+            The simulator object the parameter is pulled from
+        """
+        return self._get(simulator)
+
+
+class WritableAction(Action[SimulatorT], Generic[SimulatorT]):
+    """Base for actions that support both get and set.
+
+    Overrides ``_check_var`` so writable variables are accepted.
+    Subclasses must implement ``get`` and ``set``.
+
+    The model calls ``set``, which enforces the read-only guard before
+    delegating to ``_set``.
+    """
+
+    @model_validator(mode="after")
+    def _check_var(self) -> Self:
+        return self
+
+    @abstractmethod
+    def _set(self, simulator: SimulatorT, value: Any) -> None:
+        """
+        The child-class implementation of the set method. Overrid this method and
+        not `set` for defining the action's set method.
+
+        Parameters
+        ----------
+        simulator: SimulatorT
+            The simulator object
+        value: Any
+            The value the variable associated with the action is being set to
+        """
+        ...
+
+    def set(self, simulator: SimulatorT, value: Any) -> None:
+        """
+        Outside facing set method with read-only checking.
+
+        Parameters
+        ----------
+        simulator: SimulatorT
+            The simulator object
+        value: Any
+            The value the variable associated with the action is being set to
+        """
+        if self.var.read_only:
+            raise ReadOnlyError(f"'{self.name}' is read-only")
+        self._set(simulator, value)

--- a/lume/actions.py
+++ b/lume/actions.py
@@ -1,104 +1,140 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar, Self
+from typing import Any, Generic, TypeVar
 
-from pydantic import BaseModel, model_validator
+from pydantic import field_validator
 
-from lume.variables import Variable
 from lume.exceptions import ReadOnlyError
 
 SimulatorT = TypeVar("SimulatorT")
 
 
-class Action(ABC, BaseModel, Generic[SimulatorT]):
-    """Base for read-only actions over a generic simulator type.
+class Action(ABC, Generic[SimulatorT]):
+    """
+    Parent class for testing if something is an Action.
 
-    Subclasses must implement ``_get``.  The ``model_validator`` enforces
-    that the associated variable is marked read-only at construction time.
+    Do not subclass directly. Use ``ReadOnlyActionMixin`` or
+    ``WritableActionMixin`` mixed into a ``Variable`` subclass.
     """
 
-    var: Variable
 
-    @property
-    def name(self) -> str:
-        return self.var.name
+class ReadOnlyActionMixin(Action[SimulatorT], Generic[SimulatorT]):
+    """Mixin for read-only variable-actions.
 
-    @property
-    def read_only(self) -> bool:
-        return getattr(self.var, "read_only")
+    Mix into a ``Variable`` subclass. The variable must be constructed with
+    ``read_only=True``; the field validator enforces this at construction time.
+    Subclasses must implement ``_get``.
+    """
 
-    @model_validator(mode="after")
-    def _check_var(self) -> "Action[SimulatorT]":
-        if not self.var.read_only:
-            raise ReadOnlyError(f"{type(self).__name__} requires a read-only variable")
-        return self
+    @field_validator("read_only", mode="after")
+    @classmethod
+    def _check_read_only(cls, v: bool) -> bool:
+        if not v:
+            raise ReadOnlyError(f"{cls.__name__} requires read_only=True")
+        return v
 
     @abstractmethod
     def _get(self, simulator: SimulatorT) -> Any:
-        """
-        The child-class implementation of the get method. Override this method and
-        not `get` for defining the action's functionality.
+        """Return the current value from ``simulator``. User-implemented version, not ``get``.
 
         Parameters
         ----------
-        simulator: SimulatorT
-            The simulator object the parameter is pulled from
+        simulator : SimulatorT
+            The simulator to read from.
+
+        Returns
+        -------
+        Any
+            The current value of this variable in the simulator.
         """
         ...
 
     def get(self, simulator: SimulatorT) -> Any:
-        """
-        Outside facing get method.
+        """Return the current value from ``simulator``. Do not override, put your implementation in _get instead.
 
         Parameters
         ----------
-        simulator: SimulatorT
-            The simulator object the parameter is pulled from
+        simulator : SimulatorT
+            The simulator to read from.
+
+        Returns
+        -------
+        Any
+            The current value of this variable in the simulator.
         """
         return self._get(simulator)
 
 
-class WritableAction(Action[SimulatorT], Generic[SimulatorT]):
-    """Base for actions that support both get and set.
+class WritableActionMixin(Action[SimulatorT], Generic[SimulatorT]):
+    """Mixin for writable variable-actions.
 
-    Overrides ``_check_var`` so writable variables are accepted.
-    Subclasses must implement ``get`` and ``set``.
+    Mix into a ``Variable`` subclass. Subclasses must implement ``_get`` and
+    ``_set``.
 
-    The model calls ``set``, which enforces the read-only guard before
-    delegating to ``_set``.
+    Calling ``set`` on a variable with ``read_only=True`` raises
+    ``ReadOnlyError`` at runtime.
     """
 
-    @model_validator(mode="after")
-    def _check_var(self) -> Self:
-        return self
-
     @abstractmethod
-    def _set(self, simulator: SimulatorT, value: Any) -> None:
-        """
-        The child-class implementation of the set method. Overrid this method and
-        not `set` for defining the action's set method.
+    def _get(self, simulator: SimulatorT) -> Any:
+        """Return the current value from ``simulator``. User implemented version.
 
         Parameters
         ----------
-        simulator: SimulatorT
-            The simulator object
-        value: Any
-            The value the variable associated with the action is being set to
+        simulator : SimulatorT
+            The simulator to read from.
+
+        Returns
+        -------
+        Any
+            The current value of this variable in the simulator.
         """
         ...
 
-    def set(self, simulator: SimulatorT, value: Any) -> None:
-        """
-        Outside facing set method with read-only checking.
+    @abstractmethod
+    def _set(self, simulator: SimulatorT, value: Any) -> None:
+        """Write ``value`` to ``simulator``. User implemented version.
 
         Parameters
         ----------
-        simulator: SimulatorT
-            The simulator object
-        value: Any
-            The value the variable associated with the action is being set to
+        simulator : SimulatorT
+            The simulator to write to.
+        value : Any
+            The value to assign to this variable in the simulator.
         """
-        if self.var.read_only:
+        ...
+
+    def get(self, simulator: SimulatorT) -> Any:
+        """Return the current value from ``simulator``. Please override _get instead of this.
+
+        Parameters
+        ----------
+        simulator : SimulatorT
+            The simulator to read from.
+
+        Returns
+        -------
+        Any
+            The current value of this variable in the simulator.
+        """
+        return self._get(simulator)
+
+    def set(self, simulator: SimulatorT, value: Any) -> None:
+        """Write ``value`` to ``simulator``. Please override _set instead of this.
+
+        Parameters
+        ----------
+        simulator : SimulatorT
+            The simulator to write to.
+        value : Any
+            The value to assign to this variable in the simulator.
+
+        Raises
+        ------
+        ReadOnlyError
+            If this variable has ``read_only=True``.
+        """
+        if self.read_only:
             raise ReadOnlyError(f"'{self.name}' is read-only")
         self._set(simulator, value)

--- a/lume/actions.py
+++ b/lume/actions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, Union
 
 from pydantic import field_validator
 
@@ -10,6 +10,9 @@ from lume.model import LUMEModel
 from lume.variables import Variable
 
 SimulatorT = TypeVar("SimulatorT")
+
+###############################################################################
+# Action definitions
 
 
 class Action(ABC, Generic[SimulatorT]):
@@ -93,6 +96,39 @@ class WritableActionMixin(Action[SimulatorT], Generic[SimulatorT]):
         ...
 
 
+###############################################################################
+# Type hint stubs: these classes are used only to get correct type hints for
+# the action variable objects in ActionModel below and are not meant for use
+# outside of this module.
+
+
+class ReadOnlyActionVariable(ReadOnlyActionMixin, Variable):
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError("This is a type hinting stub")
+
+    def _get(self, simulator: SimulatorT) -> Any:
+        raise NotImplementedError("This is a type hinting stub")
+
+
+class WritableActionVariable(WritableActionMixin, Variable):
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError("This is a type hinting stub")
+
+    def _get(self, simulator: SimulatorT) -> Any:
+        raise NotImplementedError("This is a type hinting stub")
+
+    def _set(self, simulator: SimulatorT) -> Any:
+        raise NotImplementedError("This is a type hinting stub")
+
+
+# Type which will have the correct interface from user-provided variables
+ActionVariable = Union[ReadOnlyActionVariable, WritableActionVariable]
+
+
+###############################################################################
+# Model definition
+
+
 class ActionModel(LUMEModel, Generic[SimulatorT]):
     """LUMEModel backed by a collection of action variables.
 
@@ -118,15 +154,15 @@ class ActionModel(LUMEModel, Generic[SimulatorT]):
     def __init__(
         self,
         simulator: SimulatorT,
-        action_variables: list[Variable],
+        action_variables: list[ActionVariable],
     ) -> None:
         self.simulator = simulator
-        self._action_variable_by_name: dict[str, Variable] = {}
+        self._action_variable_by_name: dict[str, ActionVariable] = {}
         for av in action_variables:
             self.register_action_variable(av)
 
     @property
-    def supported_variables(self) -> dict[str, Variable]:
+    def supported_variables(self) -> dict[str, ActionVariable]:
         return dict(self._action_variable_by_name)
 
     def _get(self, names: list[str]) -> dict[str, Any]:
@@ -148,7 +184,7 @@ class ActionModel(LUMEModel, Generic[SimulatorT]):
             }
         )
 
-    def register_action_variable(self, action_variable: Variable) -> None:
+    def register_action_variable(self, action_variable: ActionVariable) -> None:
         """Add an action variable to the model, replacing any with the same name.
 
         Parameters

--- a/lume/exceptions.py
+++ b/lume/exceptions.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+class ReadOnlyError(TypeError):
+    """Raised when a write is attempted on a read-only variable."""

--- a/lume/model.py
+++ b/lume/model.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from lume.variables import Variable
+from lume.exceptions import ReadOnlyError
 
 
 class LUMEModel(ABC):
@@ -121,7 +122,9 @@ class LUMEModel(ABC):
                     )
 
                 if variable.read_only:
-                    raise ValueError(f"Variable '{name}' is read-only. Cannot be set.")
+                    raise ReadOnlyError(
+                        f"Variable '{name}' is read-only. Cannot be set."
+                    )
                 try:
                     variable.validate_value(values[name])
                 except (ValueError, TypeError) as exc:

--- a/lume/tests/test_actions.py
+++ b/lume/tests/test_actions.py
@@ -23,92 +23,92 @@ class MockWritableVar(WritableActionMixin, ScalarVariable):
         simulator.values[self.name] = value
 
 
+@pytest.fixture
+def sim():
+    return MockSim()
+
+
+@pytest.fixture
+def readonly_var():
+    return MockReadOnlyVar(name="x", read_only=True)
+
+
+@pytest.fixture
+def writable_var():
+    return MockWritableVar(name="y")
+
+
 class TestReadOnlyActionMixin:
     def test_construction_requires_read_only(self):
         with pytest.raises(ReadOnlyError):
             MockReadOnlyVar(name="x", read_only=False)
 
-    def test_get(self):
-        sim = MockSim()
+    def test_get(self, sim, readonly_var):
         sim.values["x"] = 3.14
-        var = MockReadOnlyVar(name="x", read_only=True)
-        assert var._get(sim) == 3.14
+        assert readonly_var._get(sim) == 3.14
 
-    def test_no_set_method(self):
-        var = MockReadOnlyVar(name="x", read_only=True)
-        assert not hasattr(var, "set")
+    def test_no_set_method(self, readonly_var):
+        assert not hasattr(readonly_var, "set")
 
 
 class TestWritableActionMixin:
-    def test_construction_writable(self):
-        var = MockWritableVar(name="x")
-        assert var.read_only is False
+    def test_construction_writable(self, writable_var):
+        assert writable_var.read_only is False
 
-    def test_get(self):
-        sim = MockSim()
+    def test_get(self, sim, writable_var):
         sim.values["y"] = 42.0
-        var = MockWritableVar(name="y")
-        assert var._get(sim) == 42.0
+        assert writable_var._get(sim) == 42.0
 
-    def test_set(self):
-        sim = MockSim()
-        var = MockWritableVar(name="y")
-        var._set(sim, 7.0)
+    def test_set(self, sim, writable_var):
+        writable_var._set(sim, 7.0)
         assert sim.values["y"] == 7.0
 
 
+@pytest.fixture
+def action_model():
+    s = MockSim()
+    avs = [
+        MockWritableVar(name="x", default_value=1.0),
+        MockReadOnlyVar(name="y", read_only=True),
+    ]
+    return ActionModel(s, avs)
+
+
 class TestActionModel:
-    def _make_model(self):
-        sim = MockSim()
-        avs = [
-            MockWritableVar(name="x", default_value=1.0),
-            MockReadOnlyVar(name="y", read_only=True),
-        ]
-        return ActionModel(sim, avs)
+    def test_supported_variables(self, action_model):
+        assert set(action_model.supported_variables) == {"x", "y"}
 
-    def test_supported_variables(self):
-        model = self._make_model()
-        assert set(model.supported_variables) == {"x", "y"}
+    def test_get(self, action_model):
+        action_model.simulator.values["y"] = 9.9
+        assert action_model.get("y") == 9.9
 
-    def test_get(self):
-        model = self._make_model()
-        model.simulator.values["y"] = 9.9
-        assert model.get("y") == 9.9
+    def test_set(self, action_model):
+        action_model.set({"x": 5.0})
+        assert action_model.simulator.values["x"] == 5.0
 
-    def test_set(self):
-        model = self._make_model()
-        model.set({"x": 5.0})
-        assert model.simulator.values["x"] == 5.0
-
-    def test_set_read_only_raises(self):
-        model = self._make_model()
+    def test_set_read_only_raises(self, action_model):
         with pytest.raises(ReadOnlyError):
-            model.set({"y": 1.0})
+            action_model.set({"y": 1.0})
 
-    def test_reset(self):
-        model = self._make_model()
-        model.simulator.values["x"] = 99.0
-        model.reset()
-        assert model.simulator.values["x"] == 1.0
+    def test_reset(self, action_model):
+        action_model.simulator.values["x"] = 99.0
+        action_model.reset()
+        assert action_model.simulator.values["x"] == 1.0
 
-    def test_register_replaces_existing(self):
-        model = self._make_model()
+    def test_register_replaces_existing(self, action_model):
         new_x = MockWritableVar(name="x", default_value=42.0)
-        model.register_action_variable(new_x)
-        assert model._action_variable_by_name["x"] is new_x
-        assert len(model.supported_variables) == 2
+        action_model.register_action_variable(new_x)
+        assert action_model._action_variable_by_name["x"] is new_x
+        assert len(action_model.supported_variables) == 2
 
-    def test_register_rejects_non_action(self):
-        model = self._make_model()
+    def test_register_rejects_non_action(self, action_model):
         with pytest.raises(ValueError):
-            model.register_action_variable(ScalarVariable(name="plain"))
+            action_model.register_action_variable(ScalarVariable(name="plain"))
 
-    def test_unregister(self):
-        model = self._make_model()
-        model.unregister_action_variable("x")
-        assert "x" not in model.supported_variables
+    def test_unregister(self, action_model):
+        action_model.unregister_action_variable("x")
+        assert "x" not in action_model.supported_variables
 
-    def test_unregister_missing_raises(self):
-        model = self._make_model()
+    def test_unregister_missing_raises(self, action_model):
         with pytest.raises(KeyError):
-            model.unregister_action_variable("nonexistent")
+            action_model.unregister_action_variable("nonexistent")

--- a/lume/tests/test_actions.py
+++ b/lume/tests/test_actions.py
@@ -106,8 +106,9 @@ class TestActionModel:
             action_model.register_action_variable(ScalarVariable(name="plain"))
 
     def test_unregister(self, action_model):
-        action_model.unregister_action_variable("x")
+        removed = action_model.unregister_action_variable("x")
         assert "x" not in action_model.supported_variables
+        assert removed.name == "x"
 
     def test_unregister_missing_raises(self, action_model):
         with pytest.raises(KeyError):

--- a/lume/tests/test_actions.py
+++ b/lume/tests/test_actions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lume.actions import Action, ActionModel, ReadOnlyActionMixin, WritableActionMixin
+from lume.actions import ActionModel, ReadOnlyActionMixin, WritableActionMixin
 from lume.exceptions import ReadOnlyError
 from lume.variables.scalar import ScalarVariable
 
@@ -21,16 +21,6 @@ class MockWritableVar(WritableActionMixin, ScalarVariable):
 
     def _set(self, simulator: MockSim, value: float) -> None:
         simulator.values[self.name] = value
-
-
-class TestAction:
-    def test_is_action_instance(self):
-        var = MockReadOnlyVar(name="x", read_only=True)
-        assert isinstance(var, Action)
-
-    def test_is_variable_instance(self):
-        var = MockReadOnlyVar(name="x", read_only=True)
-        assert isinstance(var, ScalarVariable)
 
 
 class TestReadOnlyActionMixin:

--- a/lume/tests/test_actions.py
+++ b/lume/tests/test_actions.py
@@ -1,0 +1,73 @@
+import pytest
+
+from lume.actions import Action, ReadOnlyActionMixin, WritableActionMixin
+from lume.exceptions import ReadOnlyError
+from lume.variables.scalar import ScalarVariable
+
+
+class MockSim:
+    def __init__(self):
+        self.values = {}
+
+
+class MockReadOnlyVar(ReadOnlyActionMixin, ScalarVariable):
+    def _get(self, simulator: MockSim) -> float:
+        return simulator.values.get(self.name, 0.0)
+
+
+class MockWritableVar(WritableActionMixin, ScalarVariable):
+    def _get(self, simulator: MockSim) -> float:
+        return simulator.values.get(self.name, 0.0)
+
+    def _set(self, simulator: MockSim, value: float) -> None:
+        simulator.values[self.name] = value
+
+
+class TestAction:
+    def test_is_action_instance(self):
+        var = MockReadOnlyVar(name="x", read_only=True)
+        assert isinstance(var, Action)
+
+    def test_is_variable_instance(self):
+        var = MockReadOnlyVar(name="x", read_only=True)
+        assert isinstance(var, ScalarVariable)
+
+
+class TestReadOnlyActionMixin:
+    def test_construction_requires_read_only(self):
+        with pytest.raises(ReadOnlyError):
+            MockReadOnlyVar(name="x", read_only=False)
+
+    def test_get(self):
+        sim = MockSim()
+        sim.values["x"] = 3.14
+        var = MockReadOnlyVar(name="x", read_only=True)
+        assert var.get(sim) == 3.14
+
+    def test_no_set_method(self):
+        var = MockReadOnlyVar(name="x", read_only=True)
+        assert not hasattr(var, "set")
+
+
+class TestWritableActionMixin:
+    def test_construction_writable(self):
+        var = MockWritableVar(name="x")
+        assert var.read_only is False
+
+    def test_get(self):
+        sim = MockSim()
+        sim.values["y"] = 42.0
+        var = MockWritableVar(name="y")
+        assert var.get(sim) == 42.0
+
+    def test_set(self):
+        sim = MockSim()
+        var = MockWritableVar(name="y")
+        var.set(sim, 7.0)
+        assert sim.values["y"] == 7.0
+
+    def test_set_raises_when_read_only(self):
+        sim = MockSim()
+        var = MockWritableVar(name="y", read_only=True)
+        with pytest.raises(ReadOnlyError):
+            var.set(sim, 7.0)

--- a/lume/tests/test_actions.py
+++ b/lume/tests/test_actions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lume.actions import Action, ReadOnlyActionMixin, WritableActionMixin
+from lume.actions import Action, ActionModel, ReadOnlyActionMixin, WritableActionMixin
 from lume.exceptions import ReadOnlyError
 from lume.variables.scalar import ScalarVariable
 
@@ -71,3 +71,60 @@ class TestWritableActionMixin:
         var = MockWritableVar(name="y", read_only=True)
         with pytest.raises(ReadOnlyError):
             var.set(sim, 7.0)
+
+
+class TestActionModel:
+    def _make_model(self):
+        sim = MockSim()
+        avs = [
+            MockWritableVar(name="x", default_value=1.0),
+            MockReadOnlyVar(name="y", read_only=True),
+        ]
+        return ActionModel(sim, avs)
+
+    def test_supported_variables(self):
+        model = self._make_model()
+        assert set(model.supported_variables) == {"x", "y"}
+
+    def test_get(self):
+        model = self._make_model()
+        model.simulator.values["y"] = 9.9
+        assert model.get("y") == 9.9
+
+    def test_set(self):
+        model = self._make_model()
+        model.set({"x": 5.0})
+        assert model.simulator.values["x"] == 5.0
+
+    def test_set_read_only_raises(self):
+        model = self._make_model()
+        with pytest.raises(ValueError):
+            model.set({"y": 1.0})
+
+    def test_reset(self):
+        model = self._make_model()
+        model.simulator.values["x"] = 99.0
+        model.reset()
+        assert model.simulator.values["x"] == 1.0
+
+    def test_register_replaces_existing(self):
+        model = self._make_model()
+        new_x = MockWritableVar(name="x", default_value=42.0)
+        model.register_action_variable(new_x)
+        assert model._action_variable_by_name["x"] is new_x
+        assert len(model.supported_variables) == 2
+
+    def test_register_rejects_non_action(self):
+        model = self._make_model()
+        with pytest.raises(ValueError):
+            model.register_action_variable(ScalarVariable(name="plain"))
+
+    def test_unregister(self):
+        model = self._make_model()
+        model.unregister_action_variable("x")
+        assert "x" not in model.supported_variables
+
+    def test_unregister_missing_raises(self):
+        model = self._make_model()
+        with pytest.raises(KeyError):
+            model.unregister_action_variable("nonexistent")

--- a/lume/tests/test_actions.py
+++ b/lume/tests/test_actions.py
@@ -42,7 +42,7 @@ class TestReadOnlyActionMixin:
         sim = MockSim()
         sim.values["x"] = 3.14
         var = MockReadOnlyVar(name="x", read_only=True)
-        assert var.get(sim) == 3.14
+        assert var._get(sim) == 3.14
 
     def test_no_set_method(self):
         var = MockReadOnlyVar(name="x", read_only=True)
@@ -58,19 +58,13 @@ class TestWritableActionMixin:
         sim = MockSim()
         sim.values["y"] = 42.0
         var = MockWritableVar(name="y")
-        assert var.get(sim) == 42.0
+        assert var._get(sim) == 42.0
 
     def test_set(self):
         sim = MockSim()
         var = MockWritableVar(name="y")
-        var.set(sim, 7.0)
+        var._set(sim, 7.0)
         assert sim.values["y"] == 7.0
-
-    def test_set_raises_when_read_only(self):
-        sim = MockSim()
-        var = MockWritableVar(name="y", read_only=True)
-        with pytest.raises(ReadOnlyError):
-            var.set(sim, 7.0)
 
 
 class TestActionModel:
@@ -98,7 +92,7 @@ class TestActionModel:
 
     def test_set_read_only_raises(self):
         model = self._make_model()
-        with pytest.raises(ValueError):
+        with pytest.raises(ReadOnlyError):
             model.set({"y": 1.0})
 
     def test_reset(self):

--- a/lume/tests/test_model.py
+++ b/lume/tests/test_model.py
@@ -4,6 +4,7 @@ import yaml
 import pytest
 from lume.model import LUMEModel
 from lume.variables import Variable, ScalarVariable, ConfigEnum
+from lume.exceptions import ReadOnlyError
 
 
 # Mock Variable subclass for testing
@@ -148,7 +149,7 @@ class TestLUMEModel:
 
     def test_set_read_only_variable(self, model):
         """Test setting a read-only variable raises ValueError."""
-        with pytest.raises(ValueError, match="Variable 'output_var' is read-only"):
+        with pytest.raises(ReadOnlyError, match="Variable 'output_var' is read-only"):
             model.set({"output_var": 100.0})
 
     def test_set_variable_validation_error(self, model):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,10 @@ nav:
       - Base: api/base.md
       - CommandWrapper: api/command_wrapper.md
       - Tools: api/tools.md
+    - Examples:
+      - Input Parsing: examples/input_parsing.ipynb
+      - Lume Model: examples/lume_model.ipynb
+      - Actions: examples/lume_model_actions.ipynb
 
 theme:
   icon:
@@ -46,6 +50,7 @@ extra:
 
 plugins:
     - search
+    - mkdocs-jupyter
     - mkdocstrings:
         default_handler: python
         handlers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ docs = [
   "mkdocs-material",
   "livereload",
   "pytkdocs[numpy-style]",
+  "mkdocs-jupyter",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Summary of changes:
- New actions classes
- New actions model
- On setting a read-only variable, model emits a `ReadOnlyError` instead of `ValueError`
- New example notebook on actions
- Add all notebooks to mkdocs site

----

This PR introduces a new "actions framwork" which simplifies building certain types of LUME models. In this framework, mixin classes `ReadableActionMixin` and `WritableActionMixin` are used to add `.get(...)` and `.set(...)` methods to the `Variable` class's interface. These methods act on a simulator object.

In concrete implementations (ie user code or the lume subpackages), variables would be implemented as follows. I use `Impact` for this example to make it explicit.
```python
from lume.actions import WritableAction
from lume.variables  import ScalarVariable

class EleActionVariable(ScalarVariable, WritableAction[Impact]):
  """
  This variable acts on the simulator (ie Impact from the lume-impact package) and changes one attribute of one element with the given names.
  """
  # Action variables are still pydantic objects since they are variables  
  ele_name: str
  attribute_name: str

  # Action variable stores both method to "talk to" simulator and the data needed to parameterize it
  def _get(self, simulator: Impact) -> float:
    return simulator.ele[self.ele_name][self.attribute_name]

  def _set(self, simulator: Impact, value: Any) -> float:
    simulator.ele[self.ele_name][self.attribute_name] = value
```

Since the action is a variable in its own right, it no longer owns a variable as in the implementation in lume-impact. This also makes some things easier for validation. For instance, A `EleAction` just is a `ScalarVariable` and validation does not need to happen to determine if the associated variable is of the correct type for the methods talking to the simulator.

The action variables then get registered in a `LUMEModel` class which passes get and set calls to the underlying variables. Since these are variables now inside, this is a simple class and you are just passing your variables to it.

```python
from impact import Impact
from lume.actions import ActionModel

# Create your simulator
imp = Impact("my_config.in")

# Create model with a variable to a solenoid
my_var = EleActionVariable(name="SOL1:CUR", unit="A", ele_name="DIAG1_SOL1", attribute_name="current")
model = ActionModel(simulator=imp, action_variables=[my_var])

# Variables may be registered on the fly
new_var = EleActionVariable(name="CAV1:PHASE", unit="degree", ele_name="CM1_CAV1", attribute_name="phase_deg")
model.register_action_variable(new_var)
```

## TODO
- [ ] Add documentation and examples