### PR TITLE
BUG: correct the type of NDVariable.dtype default value

### DIFF
--- a/lume/variables/ndvariable.py
+++ b/lume/variables/ndvariable.py
@@ -64,7 +64,7 @@ class NDVariable(Variable):
     model_config = ConfigDict(arbitrary_types_allowed=True, validate_assignment=True)
 
     shape: Tuple[int, ...]
-    dtype: np.dtype = np.float64
+    dtype: np.dtype = np.dtype(np.float64)
     default_value: Optional[NDArray] = None
     unit: Optional[str] = None
 


### PR DESCRIPTION
## Description
- Correct the type of the default value for `NDVariable.dtype`
 
## Context 
NDVariable expects a `np.dtype` in it's `dtype` field, not a `np.float` scalar value type.  The class has multiple validators ensuring that assignment of this attribute is coerced correctly, but pydantic doesn't validate default values unless told to.

See: https://numpy.org/doc/stable/reference/arrays.dtypes.html
> Note that the scalar types are not [dtype](https://numpy.org/doc/stable/reference/generated/numpy.dtype.html#numpy.dtype) objects, even though they can be used in place of one whenever a data type specification is needed in NumPy.

This is relevant now that we have lume-pva inspecting these dtypes and expecting proper types.