### PR TITLE
`variable_class` -> computed field; drop on deserialization

### DIFF
--- a/lume/tests/variables/test_variable.py
+++ b/lume/tests/variables/test_variable.py
@@ -67,6 +67,10 @@ class TestVariable:
         assert dumped["name"] == "test_var"
         assert dumped["read_only"] is True
         assert dumped["default_validation_config"] == "error"
+        assert (
+            ConcreteVariable(**dumped).model_dump()["variable_class"]
+            == "ConcreteVariable"
+        )
 
     def test_validate_value_implementation(self):
         """Test that concrete implementation works."""

--- a/lume/variables/variable.py
+++ b/lume/variables/variable.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, computed_field, model_validator
 
 
 class ConfigEnum(str, Enum):
@@ -62,10 +62,18 @@ class Variable(BaseModel, ABC):
             config = ConfigEnum(config)
         return config
 
+    @model_validator(mode="before")
+    @classmethod
+    def _drop_variable_class(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            data = {k: v for k, v in data.items() if k != "variable_class"}
+        return data
+
+    @computed_field
+    @property
+    def variable_class(self) -> str:
+        return self.__class__.__name__
+
     @abstractmethod
     def validate_value(self, value: Any, config: ConfigEnum = None):
         pass
-
-    def model_dump(self, **kwargs) -> dict[str, Any]:
-        config = super().model_dump(**kwargs)
-        return {"variable_class": self.__class__.__name__} | config


### PR DESCRIPTION
This PR converts `variable_class` to a computed field (the more pydantic way of doing it) and adds a before validator to drop on deserialization so `extra="forbid"` works correctly.